### PR TITLE
`curl` should follow Github's redirects to the raw file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ commands for your editing pleasure.
 In your shell:
 
     cd ~/.emacs.d/vendor
-    curl -O https://github.com/mustache/emacs/raw/master/mustache-mode.el
+    curl --location -O https://github.com/mustache/emacs/raw/master/mustache-mode.el
 
 In your Emacs config:
 


### PR DESCRIPTION
The example in the Readme.md needs an extra parameter to follow Github's redirects.
Thanks!
