### PR TITLE
Resolved an indentation issue of {{^.

### DIFF
--- a/mustache-mode.el
+++ b/mustache-mode.el
@@ -77,8 +77,8 @@
 (defconst mustache-mode-section (concat "\\({{[#^/]\s*"
                                    mustache-mode-mustache-token
                                    "\s*}}\\)"))
-(defconst mustache-mode-open-section (concat "\\({{#\s*"
-                                        mustache-mode-mustache-token
+(defconst mustache-mode-open-section (concat "\\({{[#^]\s*"
+                                             mustache-mode-mustache-token
                                         "\s*}}\\)"))
 (defconst mustache-mode-close-section (concat "{{/\\(\s*"
                                          mustache-mode-mustache-token


### PR DESCRIPTION
Contents in {{^ was not indent properly.
This patch solves that.
## Before

<pre>
{{#repo}}
  {{name}}
{{/repo}}
{{^repo}}
No repos :(
{{/repo}}
</pre>

## After

<pre>
{{#repo}}
  {{name}}
{{/repo}}
{{^repo}}
  No repos :(
{{/repo}}
</pre>
